### PR TITLE
Fix Spanish comment typo

### DIFF
--- a/economia/2020-05-09-la-inconformidad-por-el-recorte-presupuestario-se-destapo-en-twitter/2020-05-09-la-inconformidad-por-el-recorte-presupuestario-se-destapo-en-twitter.Rmd
+++ b/economia/2020-05-09-la-inconformidad-por-el-recorte-presupuestario-se-destapo-en-twitter/2020-05-09-la-inconformidad-por-el-recorte-presupuestario-se-destapo-en-twitter.Rmd
@@ -6,7 +6,7 @@ date: '2020-05-09'
 
 ```{r, eval=FALSE}
 
-# Este es el código que descarga los twits
+# Este es el código que descarga los tuits
 library(rtweet)
 
 recorte_1 <- search_tweets("#NoAlRecorte", n = 12000, include_rts = FALSE)


### PR DESCRIPTION
## Summary
- fix a typo in the R Markdown comment regarding tweet downloads

## Testing
- `grep -n "descarga" -n economia/2020-05-09-la-inconformidad-por-el-recorte-presupuestario-se-destapo-en-twitter/2020-05-09-la-inconformidad-por-el-recorte-presupuestario-se-destapo-en-twitter.Rmd`

------
https://chatgpt.com/codex/tasks/task_b_68813ba7c08c832dadfa1503c0e67135